### PR TITLE
Add command-line interface

### DIFF
--- a/afids_regrf/apply.py
+++ b/afids_regrf/apply.py
@@ -112,7 +112,7 @@ def gen_parser() -> ArgumentParser:
     )
     parser.add_argument(
         "--feature_offsets_path",
-        nargs="1",
+        nargs="?",
         type=str,
         help=(
             "Path to featuers_offsets.npz file"
@@ -120,7 +120,7 @@ def gen_parser() -> ArgumentParser:
     )
     parser.add_argument(
         "--model_dir_path",
-        nargs=1,
+        nargs="?",
         type=str,
         help=(
             "Path to directory for saving fitted models."
@@ -152,7 +152,7 @@ def gen_parser() -> ArgumentParser:
         default=5,
         required=False,
         help=(
-            "Number of voxels in both directions along each axis to sample as 
+            "Number of voxels in both directions along each axis to sample as "
             "part of the training Default: 5"
         )
     )

--- a/afids_regrf/train.py
+++ b/afids_regrf/train.py
@@ -52,7 +52,7 @@ def train_afid_model(
     y_train = finalpredarr[:, -1]
 
     # NOTE: Should dump the model into appropriate location
-    print("training start")
+    print(f"training start - afid-{str(afid_num).zfill(2)}")
     model = regr_rf.fit(x_train, y_train)
     print("training ended")
 
@@ -110,7 +110,7 @@ def gen_parser() -> ArgumentParser:
     )
     parser.add_argument(
         "--feature_offsets_path",
-        nargs="1",
+        nargs="?",
         type=str,
         help=(
             "Path to featuers_offsets.npz file"
@@ -118,7 +118,7 @@ def gen_parser() -> ArgumentParser:
     )
     parser.add_argument(
         "--model_dir_path",
-        nargs=1,
+        nargs="?",
         type=str,
         help=(
             "Path to directory for saving fitted models."
@@ -150,7 +150,7 @@ def gen_parser() -> ArgumentParser:
         default=5,
         required=False,
         help=(
-            "Number of voxels in both directions along each axis to sample as 
+            "Number of voxels in both directions along each axis to sample as "
             "part of the training Default: 5"
         )
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,10 @@ authors = ["Your Name <you@example.com>"]
 readme = "README.md"
 packages = [{include = "afids_regrf"}]
 
+[tool.poetry.scripts]
+afids_regrf_train = "afids_regrf.train:main"
+afids_regrf_apply = "afids_regrf.apply:main"
+
 [tool.poetry.dependencies]
 python = ">3.8.1,<4"
 nibabel = "^5.0.1"


### PR DESCRIPTION
This PR adds in CLIs to both `train.py` and `apply.py`, allowing for calling of the each as a script. 

Also took advantage of this PR to add in `model_path_dir` to allow for saving and loading of models from a specific path (instead of the current working directory).

**Note: This is based on #1 and should be merged after it.**

_@ataha24 - again tagging you as I can only request 1 reviewer_