### PR TITLE
Use pandas instead of numpy where possible

### DIFF
--- a/afids_regrf/utils.py
+++ b/afids_regrf/utils.py
@@ -167,7 +167,7 @@ def gen_box_averages(img: NDArray, corner_list: pd.DataFrame) -> pd.DataFrame:
     def img_idx(type_: Literal["min", "max"], coord: Literal["x", "y", "z"]) -> NDArray:
         idx = (slice(None), slice(None), type_)
 
-        return corner_list.loc[idx, coord].to_numpy(dtype=np.int_)
+        return corner_list.loc[idx, coord].to_numpy(dtype="uint32")
 
     # n x 1 array of the sum of the voxel values in each box
     # See Cui et al. Fig. 2
@@ -253,10 +253,10 @@ def gen_feature_boxes(
     for idx in range(all_samples.shape[0]):
         corner_list.loc[(idx, slice(None), "min"), :] = (
             all_samples.loc[idx, :] + lower_offsets
-        ).to_numpy(dtype=np.uint8)
+        ).to_numpy(dtype=np.uint32)
         corner_list.loc[(idx, slice(None), "max"), :] = (
             all_samples.loc[idx, :] + higher_offsets
-        ).to_numpy(dtype=np.uint8)
+        ).to_numpy(dtype=np.uint32)
     return corner_list
 
 


### PR DESCRIPTION
This makes the code more legible I think, but in trying to reconcile it with `main`, I found that there may be some issues with the transition from world to voxel coordinates and/or voxel sampling (i.e. we used `uint8`s a lot, which would wrap indices above 255 back to zero, and changing that caused more attempts to index outside the range of the image). So, I think this works but also reveals that `main` was broken and it's possible this is broken too