### PR TITLE
Fix inconsistent usage of size args

### DIFF
--- a/afids_regrf/apply.py
+++ b/afids_regrf/apply.py
@@ -68,8 +68,8 @@ def apply_all_afid_models(
     feature_offsets_path: PathLike | str,
     model_dir_path: PathLike | str,
     padding: int = 0,
-    size: int = 1,
     sampling_rate: int = 5,
+    size: int = 1,
 ) -> None:
     """Apply a trained regRF fiducial for each of the 32 AFIDs."""
     all_afids_coords = np.empty((3,), dtype=float)
@@ -171,8 +171,8 @@ def main():
         feature_offsets_path=args.feature_offsets_path,
         model_dir_path=args.model_dir_path,
         padding=args.padding,
-        size=args.size,
         sampling_rate=args.sampling_rate,
+        size=args.size,
     )
 
 

--- a/afids_regrf/train.py
+++ b/afids_regrf/train.py
@@ -66,8 +66,8 @@ def train_all_afid_models(
     feature_offsets_path: PathLike | str,
     model_dir_path: PathLike | str,
     padding: int = 0,
-    size: int = 1,
     sampling_rate: int = 5,
+    size: int = 1,
 ) -> None:
     """Train a regRF fiducial for each of the 32 AFIDs."""
     feature_offsets = np.load(feature_offsets_path)
@@ -78,8 +78,8 @@ def train_all_afid_models(
             fcsv_paths,
             (feature_offsets["arr_0"], feature_offsets["arr_1"]),
             padding,
-            size,
             sampling_rate,
+            size,
         )
 
         # Save model
@@ -158,8 +158,8 @@ def main():
         feature_offsets_path=args.feature_offsets_path,
         model_dir_path=args.model_dir_path,
         padding=args.padding,
-        size=args.size,
         sampling_rate=args.sampling_rate,
+        size=args.size,
     )
 
 

--- a/afids_regrf/utils.py
+++ b/afids_regrf/utils.py
@@ -11,6 +11,7 @@ import nibabel as nib
 import numpy as np
 import pandas as pd
 from numpy.typing import NDArray
+from scipy.ndimage import zoom
 from typing_extensions import Literal
 
 AFIDS_FIELDNAMES = [
@@ -300,6 +301,7 @@ def gen_features(
 
     # Get and compute new fiducial location
     resampled_fid = fid_world2voxel(fiducial, aff, resample_size=size, padding=padding)
+    img = zoom(img, size)
 
     # Get image samples (sample more closer to target)
     # Concatenate and retain unique samples and
@@ -340,7 +342,7 @@ def gen_features(
 
         return [np.hstack((diff[index], prob[index])) for index in range(prob.shape[0])]
     # Features for prediction
-    return aff, diff, all_samples
+    return aff, diff, all_samples.to_numpy(dtype=np.int_)
 
 
 def afids_to_fcsv(


### PR DESCRIPTION
This PR fixes two things:

1. The `size` and `sampling_rate` args were switched in some places, leading to errors -- Now they're in the same order everywhere they're both used.
2. The `size` arg was only changing the fiducials, not resampling the image, leading to a lot of the "out of bounds" indices we were seeing.